### PR TITLE
Create objects with `new`

### DIFF
--- a/lib/gunk.js
+++ b/lib/gunk.js
@@ -48,6 +48,12 @@ function Literal(value) {
 }
 gunk.Literal = Literal;
 
+function nConstructor(n) {
+  var names = 'abcdefghijklmnopqrstuvwxyz'.split('').slice(0, n);
+  var code = 'return new C(' + names.join(', ') + ');';
+  return Function.apply(null, ['C'].concat(names, code));
+}
+
 gunk.construct = function(C /* , *additionalParameters */) {
   var additionalParameters = [].slice.call(arguments, 1);
 
@@ -56,9 +62,9 @@ gunk.construct = function(C /* , *additionalParameters */) {
     var parameters = args.slice(0, -1);
     var cb = args.slice(-1)[0];
 
-    var object = Object.create(C.prototype);
     try {
-      C.apply(object, parameters);
+      var constructor = nConstructor(parameters.length);
+      var object = constructor.apply(null, [C].concat(parameters));
       cb(null, object);
     } catch (e) {
       cb(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gunk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Dependency injection framework for node.js",
   "main": "lib/gunk.js",
   "scripts": {


### PR DESCRIPTION
Use `new` instead of `Object.create()` to construct objects. Using the
`Object.create()` pattern to create objects prevents hidden class
optimisation and display of class names in heap dumps.